### PR TITLE
FIXED “Fails due to case-sensitive REL attribute condition”

### DIFF
--- a/dist/livereload.js
+++ b/dist/livereload.js
@@ -332,7 +332,7 @@ __less = LessPlugin = (function() {
       _results = [];
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         link = _ref[_i];
-        if (link.href && link.rel === 'stylesheet/less' || (link.rel.match(/stylesheet/) && link.type.match(/^text\/(x-)?less$/))) {
+        if (link.href && link.rel.match(/^stylesheet\/less$/i) || (link.rel.match(/stylesheet/i) && link.type.match(/^text\/(x-)?less$/i))) {
           _results.push(link);
         }
       }
@@ -701,7 +701,7 @@ __reloader.Reloader = Reloader = (function() {
       _results = [];
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         link = _ref[_i];
-        if (link.rel === 'stylesheet' && !link.__LiveReload_pendingRemoval) {
+        if (link.rel.match(/^stylesheet$/i) && !link.__LiveReload_pendingRemoval) {
           _results.push(link);
         }
       }

--- a/src/less.coffee
+++ b/src/less.coffee
@@ -14,7 +14,7 @@ module.exports = class LessPlugin
     no
 
   reloadLess: (path) ->
-    links = (link for link in document.getElementsByTagName('link') when link.href and link.rel is 'stylesheet/less' or (link.rel.match(/stylesheet/) and link.type.match(/^text\/(x-)?less$/)))
+    links = (link for link in document.getElementsByTagName('link') when link.href and link.rel.match(/^stylesheet\/less$/i) or (link.rel.match(/stylesheet/i) and link.type.match(/^text\/(x-)?less$/i)))
 
     return no if links.length is 0
 

--- a/src/reloader.coffee
+++ b/src/reloader.coffee
@@ -148,7 +148,7 @@ exports.Reloader = class Reloader
 
   reloadStylesheet: (path) ->
     # has to be a real array, because DOMNodeList will be modified
-    links = (link for link in @document.getElementsByTagName('link') when link.rel is 'stylesheet' and not link.__LiveReload_pendingRemoval)
+    links = (link for link in @document.getElementsByTagName('link') when link.rel.match(/^stylesheet$/i) and not link.__LiveReload_pendingRemoval)
 
     # find all imported stylesheets
     imported = []


### PR DESCRIPTION
I'm using livereload via `node-livereload` and/or `guard-livereload` on a legacy Rails project running the `asset_packager` helper (before Rails had this built-in). It took me forever to figure out that `livereload.js` was actually working, but checking for linked stylesheets using `xxx.rel === 'stylesheet'`, which failed to trigger because the old asset packager was writing its tags using `rel = "Stylesheet"`...

I've fixed this in a feature branch, and will submit a pull request shortly.

Btw: I'd already fixed this in these guy's versions of `livereload.js`:
https://github.com/guard/guard-livereload/issues/118
https://github.com/napcs/node-livereload/pull/28
but thought it finally better to fix the source...