### PR TITLE
Use WSS when livereload.js is on HTTPS.

### DIFF
--- a/dist/livereload.js
+++ b/dist/livereload.js
@@ -12,7 +12,7 @@
       this.WebSocket = WebSocket;
       this.Timer = Timer;
       this.handlers = handlers;
-      this._uri = "ws://" + this.options.host + ":" + this.options.port + "/livereload";
+      this._uri = "ws" + (this.options.https ? "s" : "") + "://" + this.options.host + ":" + this.options.port + "/livereload";
       this._nextDelay = this.options.mindelay;
       this._connectionDesired = false;
       this.protocol = 0;
@@ -462,6 +462,7 @@
 
   exports.Options = Options = (function() {
     function Options() {
+      this.https = false;
       this.host = null;
       this.port = 35729;
       this.snipver = null;
@@ -493,6 +494,7 @@
       element = _ref[_i];
       if ((src = element.src) && (m = src.match(/^[^:]+:\/\/(.*)\/z?livereload\.js(?:\?(.*))?$/))) {
         options = new Options();
+        options.https = src.indexOf("https") === 0;
         if (mm = m[1].match(/^([^\/:]+)(?::(\d+))?$/)) {
           options.host = mm[1];
           if (mm[2]) {

--- a/src/connector.coffee
+++ b/src/connector.coffee
@@ -5,7 +5,8 @@ Version = '2.2.1'
 exports.Connector = class Connector
 
   constructor: (@options, @WebSocket, @Timer, @handlers) ->
-    @_uri = "ws://#{@options.host}:#{@options.port}/livereload"
+    @_uri = "ws#{if @options.https then "s" else ""}://#{@options.host}:#{@options.port}/livereload"
+
     @_nextDelay = @options.mindelay
     @_connectionDesired = no
     @protocol = 0

--- a/src/options.coffee
+++ b/src/options.coffee
@@ -1,5 +1,6 @@
 exports.Options = class Options
   constructor: ->
+    @https   = false
     @host    = null
     @port    = 35729
 
@@ -24,6 +25,7 @@ Options.extract = (document) ->
   for element in document.getElementsByTagName('script')
     if (src = element.src) && (m = src.match ///^ [^:]+ :// (.*) / z?livereload\.js (?: \? (.*) )? $///)
       options = new Options()
+      options.https = src.indexOf("https") is 0
       if mm = m[1].match ///^ ([^/:]+) (?: : (\d+) )? $///
         options.host = mm[1]
         if mm[2]

--- a/test/connector_test.coffee
+++ b/test/connector_test.coffee
@@ -206,3 +206,14 @@ describe "Connector", ->
 
     shouldReconnect handlers, timer, yes, ->
       connectAndTimeoutHandshake handlers, timer, webSocket
+
+  it "should use wss protocol with https option", ->
+    handlers  = new MockHandlers()
+    timer     = newMockTimer()
+    webSocket = newMockWebSocket()
+    options   = new Options()
+    options.https = true
+    options.host = "localhost"
+    connector = new Connector(options, webSocket, timer, handlers)
+
+    assert.equal "wss://localhost:35729/livereload", connector._uri

--- a/test/options_test.coffee
+++ b/test/options_test.coffee
@@ -74,3 +74,15 @@ describe "Options", ->
       assert.equal 35729, options.port
 
       done()
+
+  it "should set https when using an https URL ", (done) ->
+    jsdom.env """
+      <script src="https://somewhere.com:9876/livereload.js"></script>
+    """, [], (errors, window) ->
+      assert.ok !errors
+
+      options = Options.extract(window.document)
+      assert.ok options?
+      assert.equal true, options.https
+
+      done()


### PR DESCRIPTION
Hi,

This pull request backports [a commit from @mendenhallmagic in tiny-lr](https://github.com/mklabs/tiny-lr/commit/f97eaa57a70287dda8843e1d7aaa2ad2f577ecf9) to add the ability to use livereload over https.

Relevant pull request: https://github.com/mklabs/tiny-lr/pull/31

Thanks!