### PR TITLE
Refresh iframe css

### DIFF
--- a/dist/livereload.js
+++ b/dist/livereload.js
@@ -837,10 +837,22 @@
     };
 
     Reloader.prototype.reloadStylesheet = function(path) {
-      var imported, link, links, match, style, _i, _j, _k, _l, _len, _len1, _len2, _len3, _ref, _ref1;
+      var getElementsByTagNameRecursive, imported, link, links, match, style, _i, _j, _k, _l, _len, _len1, _len2, _len3, _ref, _ref1;
+      getElementsByTagNameRecursive = function(document, tagName) {
+        var elements, iframe, slice, _i, _len, _ref;
+        slice = Array.prototype.slice;
+        elements = [];
+        elements = elements.concat(slice.call(document.getElementsByTagName(tagName)));
+        _ref = document.getElementsByTagName('iframe');
+        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+          iframe = _ref[_i];
+          elements = elements.concat(slice.call(getElementsByTagNameRecursive(iframe.contentWindow.document, tagName)));
+        }
+        return elements;
+      };
       links = (function() {
         var _i, _len, _ref, _results;
-        _ref = this.document.getElementsByTagName('link');
+        _ref = getElementsByTagNameRecursive(this.document, 'link');
         _results = [];
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
           link = _ref[_i];
@@ -851,7 +863,7 @@
         return _results;
       }).call(this);
       imported = [];
-      _ref = this.document.getElementsByTagName('style');
+      _ref = getElementsByTagNameRecursive(this.document, 'style');
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         style = _ref[_i];
         if (style.sheet) {

--- a/src/reloader.coffee
+++ b/src/reloader.coffee
@@ -148,11 +148,21 @@ exports.Reloader = class Reloader
 
   reloadStylesheet: (path) ->
     # has to be a real array, because DOMNodeList will be modified
-    links = (link for link in @document.getElementsByTagName('link') when link.rel.match(/^stylesheet$/i) and not link.__LiveReload_pendingRemoval)
+
+    getElementsByTagNameRecursive = (document, tagName) ->
+      slice = Array.prototype.slice
+      elements = []
+      elements = elements.concat(slice.call(document.getElementsByTagName(tagName)))
+      
+      for iframe in document.getElementsByTagName('iframe')
+        elements = elements.concat(slice.call(getElementsByTagNameRecursive(iframe.contentWindow.document, tagName)))
+      return elements
+
+    links = (link for link in getElementsByTagNameRecursive(@document, 'link') when link.rel.match(/^stylesheet$/i) and not link.__LiveReload_pendingRemoval)
 
     # find all imported stylesheets
     imported = []
-    for style in @document.getElementsByTagName('style') when style.sheet
+    for style in getElementsByTagNameRecursive(@document, 'style') when style.sheet
       @collectImportedStylesheets style, style.sheet, imported
     for link in links
       @collectImportedStylesheets link, link.sheet, imported


### PR DESCRIPTION
Changed `Reloader::reloadStylesheet` to get `style` and `link` elements from iframes in document. Allows iframes to dynamically reload css.