### PR TITLE
Check the type of console.error before attempting to bind its context

### DIFF
--- a/src/livereload.coffee
+++ b/src/livereload.coffee
@@ -17,7 +17,7 @@ exports.LiveReload = class LiveReload
           @window.console
         else
           log:   ->
-          error: @window.console.error.bind(@window.console)
+          error: typeof @window.console.error === 'function' ? @window.console.error.bind(@window.console) : ->
       else
         log:   ->
         error: ->


### PR DESCRIPTION
When console.error is polyfilled, the polyfill may not actually put a
typical function in here, and `bind` may not be available. This causes
errors in environments like IE9 that developers might be testing
against.