### PR TITLE
support for IPv6 hosts

### DIFF
--- a/src/options.coffee
+++ b/src/options.coffee
@@ -26,7 +26,7 @@ Options.extract = (document) ->
     if (src = element.src) && (m = src.match ///^ [^:]+ :// (.*) / z?livereload\.js (?: \? (.*) )? $///)
       options = new Options()
       options.https = src.indexOf("https") is 0
-      if mm = m[1].match ///^ ([^/:]+) (?: : (\d+) )? $///
+      if mm = m[1].match ///^ ([^/]+?) (?: : (\d+) )? $///
         options.host = mm[1]
         if mm[2]
           options.port = parseInt(mm[2], 10)


### PR DESCRIPTION
Make it possible to use IPv6 addresses, like `[::1]:8000`, with `livereload.js`.

(I am no regexp expert.  It works, but I might have also broken something else.  Please make sure this is 100% correct.)
