### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Version history
 
 2.1.0 (Jan 16, 2015)
 
-* use case-insensitive matching for `rel` attribute in `<link rel="stylesheet">` tags, to accomodate legacy Rails versions
+* use case-insensitive matching for `rel` attribute in `<link rel="stylesheet">` tags, to accommodate legacy Rails versions
 * avoid usage of `console` when it's not definited
 * some README changes
 


### PR DESCRIPTION
livereload, I've corrected a typographical error in the documentation of the [livereload-js](https://github.com/livereload/livereload-js) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.