### PR TITLE
Fix repo, bugs and homepage location in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/zaius/livereload-js.git"
+    "url": "git://github.com/livereload/livereload-js.git"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/zaius/livereload-js/issues"
+    "url": "https://github.com/livereload/livereload-js/issues"
   },
-  "homepage": "https://github.com/zaius/livereload-js"
+  "homepage": "https://github.com/livereload/livereload-js"
 }


### PR DESCRIPTION
Hi! It looks like the repo, bugs and homepage location in the package.json was accidentally pointed to a fork in this commit: https://github.com/livereload/livereload-js/commit/c0a72e0fe500d9b3df0b0232a0845de8b90b49cc

This PR fixes those locations on npm: https://www.npmjs.com/package/livereload-js

Thanks!
