### PR TITLE
fix splitUrl error with combo url

### DIFF
--- a/src/reloader.coffee
+++ b/src/reloader.coffee
@@ -5,7 +5,14 @@ splitUrl = (url) ->
   else
     hash = ''
 
-  if (index = url.indexOf('?')) >= 0
+  # http://your.domain.com/path/to/combo/??file1.css,file2,css
+  comboSign = url.indexOf('??')
+  if comboSign >= 0
+    if comboSign + 1 != url.lastIndexOf('?')
+      index = url.lastIndexOf('?')
+  else
+    index = url.indexOf('?')
+  if index >= 0
     params = url.slice(index)
     url = url.slice(0, index)
   else


### PR DESCRIPTION
`splitUrl` function does not work well in [Nginx concat](https://github.com/alibaba/nginx-http-concat) url

> http://your.domain.com/path/to/combo/??file1.css,file2,css (origin)
> http://your.domain.com/path/to/combo/??file1.css,file2,css&livereload=12345 (error)
> http://your.domain.com/path/to/combo/??file1.css,file2,css?livereload=12345 (ok)
