### PR TITLE
Accept when livereload not being served from domain root

### DIFF
--- a/src/options.coffee
+++ b/src/options.coffee
@@ -26,7 +26,7 @@ Options.extract = (document) ->
     if (src = element.src) && (m = src.match ///^ [^:]+ :// (.*) / z?livereload\.js (?: \? (.*) )? $///)
       options = new Options()
       options.https = src.indexOf("https") is 0
-      if mm = m[1].match ///^ ([^/:]+) (?: : (\d+) )? $///
+      if mm = m[1].match ///^ ([^/:]+) (?: : (\d+) )? (\/+.*)?$///
         options.host = mm[1]
         if mm[2]
           options.port = parseInt(mm[2], 10)

--- a/test/options_test.coffee
+++ b/test/options_test.coffee
@@ -48,6 +48,11 @@ describe "Options", ->
     assert.equal 'somewhere.com', options.host
     assert.equal 35729, options.port
 
+  it "should accept when livereload is not being served domain root", ->
+    dom = new JSDOM("""<script src="http://somewhere.com:9876/132324324/23243443/4343/livereload.js"></script>""")
+    options = Options.extract(dom.window.document)
+    assert.equal 'somewhere.com', options.host
+    assert.equal 9876, options.port
 
   it "should set https when using an https URL ", ->
     dom = new JSDOM("""<script src="https://somewhere.com:9876/livereload.js"></script>""")


### PR DESCRIPTION
Fixes [#1](https://github.com/livereload/livereload-js/issues/1) Changed regex to accept 
> hostname:port/sub/folder/path/livereload.js
