### PR TITLE
fix recognizing port 80

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -29,7 +29,7 @@ class Options {
 Options.extract = function (document) {
   for (const element of Array.from(document.getElementsByTagName('script'))) {
     var m, src;
-    if ((src = element.src) && (m = src.match(new RegExp(`^[^:]+://(.*)/z?livereload\\.js(?:\\?(.*))?$`)))) {
+    if ((src = element.getAttribute('src')) && (m = src.match(new RegExp('^(?:[^:]+:)?//(.*)/z?livereload\\.js(?:\\?(.*))?$')))) {
       var mm;
       const options = new Options();
 

--- a/src/options.js
+++ b/src/options.js
@@ -33,7 +33,7 @@ Options.extract = function (document) {
       var mm;
       const options = new Options();
 
-      options.https = src.indexOf('https') === 0;
+      options.https = element.src.indexOf('https') === 0;
 
       if ((mm = m[1].match(new RegExp(`^([^/:]+)(?::(\\d+))?(\\/+.*)?$`)))) {
         options.host = mm[1];

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -55,6 +55,20 @@ describe('Options', function () {
     return assert.strictEqual(9876, options.port);
   });
 
+  it('should fallback to port 35729', function () {
+    const dom = new JSDOM('<script src="http://somewhere.com/132324324/23243443/4343/livereload.js"></script>');
+    const options = Options.extract(dom.window.document);
+    assert.ok(options);
+    return assert.strictEqual(35729, options.port);
+  });
+
+  it('should recognize port 80', function () {
+    const dom = new JSDOM('<script src="http://somewhere.com:80/132324324/23243443/4343/livereload.js"></script>');
+    const options = Options.extract(dom.window.document);
+    assert.ok(options);
+    return assert.strictEqual(80, options.port);
+  });
+
   return it('should set https when using an https URL ', function () {
     const dom = new JSDOM('<script src="https://somewhere.com:9876/livereload.js"></script>');
 

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -69,9 +69,18 @@ describe('Options', function () {
     return assert.strictEqual(80, options.port);
   });
 
-  return it('should set https when using an https URL ', function () {
+  it('should set https when using an https URL', function () {
     const dom = new JSDOM('<script src="https://somewhere.com:9876/livereload.js"></script>');
 
+    const options = Options.extract(dom.window.document);
+    assert.ok(options);
+    return assert.strictEqual(true, options.https);
+  });
+
+  return it('should recognize protocol-relative https URL', function () {
+    const dom = new JSDOM('<script src="//somewhere.com/132324324/23243443/4343/livereload.js"></script>', {
+      url: 'https://somewhere.org/'
+    });
     const options = Options.extract(dom.window.document);
     assert.ok(options);
     return assert.strictEqual(true, options.https);


### PR DESCRIPTION
Possibly related to #27 

Options.extract used `element.src` to match and extract the port.
But since port 80 (and possibly 443 on https) are default, they are magically removed.
See attached screenshot.

I changed the Regular expression to make the protocol optional, since in the attribute it might be left off, whereas the `element.src` it is automatically prepended. 

<img width="407" alt="Screenshot 2019-09-01 at 00 51 53" src="https://user-images.githubusercontent.com/2684851/64069831-c2da9400-cc52-11e9-9144-9cb0fde7f2bf.png">