### PR TITLE
Fix same site urls

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -28,22 +28,26 @@ class Options {
 
 Options.extract = function (document) {
   for (const element of Array.from(document.getElementsByTagName('script'))) {
-    var m, src;
-    if ((src = element.getAttribute('src')) && (m = src.match(new RegExp('^(?:[^:]+:)?//(.*)/z?livereload\\.js(?:\\?(.*))?$')))) {
-      var mm;
+    var m, mm,
+      src = element.src, srcAttr = element.getAttribute('src');
+    var lrUrlRegexp = /^([^:]+:\/\/([^\/:]+)(?::(\d+))?\/|\/\/|\/)?([^\/].*\/)?z?livereload\.js(?:\?(.*))?$/;
+    //                   ^proto:// ^host        ^port     ^//  ^/   ^folder
+    if ((m = src.match(lrUrlRegexp)) && (mm = srcAttr.match(lrUrlRegexp))) {
+      const [, , host, port, , params] = m;
+      const [, , , portFromAttr] = mm;
       const options = new Options();
 
       options.https = element.src.indexOf('https') === 0;
 
-      if ((mm = m[1].match(new RegExp('^([^/:]+)(?::(\\d+))?(\\/+.*)?$')))) {
-        options.host = mm[1];
-        if (mm[2]) {
-          options.port = parseInt(mm[2], 10);
-        }
-      }
+      options.host = host;
+      options.port = port
+        ? parseInt(port, 10)
+        : portFromAttr
+          ? parseInt(portFromAttr, 10)
+          : options.port;
 
-      if (m[2]) {
-        for (const pair of m[2].split('&')) {
+      if (params) {
+        for (const pair of params.split('&')) {
           var keyAndValue;
 
           if ((keyAndValue = pair.split('=')).length > 1) {

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -77,11 +77,25 @@ describe('Options', function () {
     return assert.strictEqual(true, options.https);
   });
 
-  it('should recognize same site URL', function () {
-    const dom = new JSDOM('<script src="/somewhere.com/132324324/23243443/4343/livereload.js"></script>', {
+  it('should recognize same site URLs', function () {
+    let dom = new JSDOM('<script src="/somewhere.com/132324324/23243443/4343/livereload.js"></script>', {
       url: 'https://somewhere.org/'
     });
-    const options = Options.extract(dom.window.document);
+    let options = Options.extract(dom.window.document);
+    assert.ok(options);
+    assert.strictEqual('somewhere.org', options.host);
+    
+    dom = new JSDOM('<script src="livereload.js"></script>', {
+      url: 'https://somewhere.org/'
+    });
+    options = Options.extract(dom.window.document);
+    assert.ok(options);
+    assert.strictEqual('somewhere.org', options.host);
+    
+    dom = new JSDOM('<script src="../livereload.js"></script>', {
+      url: 'https://somewhere.org/'
+    });
+    options = Options.extract(dom.window.document);
     assert.ok(options);
     return assert.strictEqual('somewhere.org', options.host);
   });

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -77,6 +77,15 @@ describe('Options', function () {
     return assert.strictEqual(true, options.https);
   });
 
+  it('should recognize same site URL', function () {
+    const dom = new JSDOM('<script src="/somewhere.com/132324324/23243443/4343/livereload.js"></script>', {
+      url: 'https://somewhere.org/'
+    });
+    const options = Options.extract(dom.window.document);
+    assert.ok(options);
+    return assert.strictEqual('somewhere.org', options.host);
+  });
+
   return it('should recognize protocol-relative https URL', function () {
     const dom = new JSDOM('<script src="//somewhere.com/132324324/23243443/4343/livereload.js"></script>', {
       url: 'https://somewhere.org/'
@@ -85,4 +94,5 @@ describe('Options', function () {
     assert.ok(options);
     return assert.strictEqual(true, options.https);
   });
+
 });


### PR DESCRIPTION
I'm using locally downloaded `livereload.js` because sometimes I don't have internet access and 3.0.1 broke local urls. I'm getting message:

```
LiveReload disabled because it could not find its own <SCRIPT> tag
```

In 3.0.1 `src` attribute used to find script location, but we need to parse `src` attribute to find out explicitly written port 80 **and** `src` element property to work with same-site urls.