### PR TITLE
Plugin order

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,34 @@ The set of supported options is the same for both methods:
 * `handshake_timeout`: timeout for a protocol handshake to be completed after a connection attempt; mostly only needed if you're running an interactive debugger on your web socket server
 * `isChromeExtension`: reload chrome runtime instead of page when true (default: false)
 * `reloadMissingCSS`: prevent reload of CSS when changed stylesheet isn't found in page (default: true)
+* `pluginOrder`: overrides plugins launch order; for details see below
 
+### Plugin order
+
+By default LiveReload runs external plugins one by one, then tries live CSS reloading, live IMG reloading, reloads chrome extension and as a last resort reloads the whole page, if no plugin matched the updated file name. So, by default assume `pluginOrder = ['external', 'css', 'img', 'extension', 'others']`.
+
+Alternatively, you can define `pluginOrder` to match your workflow.
+
+If you're using `LiveReloadOptions` object on page, then define array of plugins:
+
+```javascript
+var LiveReloadOptions = {
+    ...,
+    pluginOrder: ['css', 'img'],
+    // or
+    pluginOrder: 'css img'.split(' ')
+}
+```
+
+If you're configuring LivReload using `<script>` tag, then use following syntax:
+
+```html
+<script src="//livereload.js?pluginOrder=css,img">
+```
+
+This means LiveReload will only try to do live `css` and `img` reloading, regardless of any external plugins.
+
+You can specify external plugins order by adding each plugin id into `pluginOrder` or just use `external` to run all external plugins in default order.
 
 Issues & Limitations
 --------------------

--- a/src/livereload.js
+++ b/src/livereload.js
@@ -128,7 +128,8 @@ class LiveReload {
       reloadMissingCSS: message.reloadMissingCSS != null ? message.reloadMissingCSS : true,
       originalPath: message.originalPath || '',
       overrideURL: message.overrideURL || '',
-      serverURL: `http://${this.options.host}:${this.options.port}`
+      serverURL: `http://${this.options.host}:${this.options.port}`,
+      pluginOrder: message.pluginOrder
     });
   }
 

--- a/src/livereload.js
+++ b/src/livereload.js
@@ -129,7 +129,7 @@ class LiveReload {
       originalPath: message.originalPath || '',
       overrideURL: message.overrideURL || '',
       serverURL: `http://${this.options.host}:${this.options.port}`,
-      pluginOrder: message.pluginOrder
+      pluginOrder: this.options.pluginOrder
     });
   }
 

--- a/src/options.js
+++ b/src/options.js
@@ -12,7 +12,11 @@ class Options {
     this.maxdelay = 60000;
     this.handshake_timeout = 5000;
 
-    this.pluginOrder = undefined;
+    var pluginOrder = [];
+    Object.defineProperty(this, 'pluginOrder', {
+      get () { return pluginOrder; },
+      set (v) { pluginOrder.push.apply(pluginOrder, v.split(/[,;]/)); }
+    });
   }
 
   set (name, value) {

--- a/src/options.js
+++ b/src/options.js
@@ -11,6 +11,8 @@ class Options {
     this.mindelay = 1000;
     this.maxdelay = 60000;
     this.handshake_timeout = 5000;
+
+    this.pluginOrder = undefined;
   }
 
   set (name, value) {

--- a/src/reloader.js
+++ b/src/reloader.js
@@ -136,38 +136,38 @@ class Reloader {
   }
 
   runPluginsByOrder (path, options) {
-    options.pluginOrder.forEach (pluginId => {
-      
+    options.pluginOrder.some(pluginId => {
       if (pluginId === 'css') {
         if (options.liveCSS && path.match(/\.css(?:\.map)?$/i)) {
           if (this.reloadStylesheet(path)) {
-            return;
+            return true;
           }
         }
       }
       if (pluginId === 'img') {
         if (options.liveImg && path.match(/\.(jpe?g|png|gif)$/i)) {
           this.reloadImages(path);
-          return;
+          return true;
         }
       }
       if (pluginId === 'extension') {
         if (options.isChromeExtension) {
           this.reloadChromeExtension();
-          return;
+          return true;
         }
       }
       if (pluginId === 'others') {
-        return this.reloadPage();
+        this.reloadPage();
+        return true;
       }
 
-      this.plugins.filter (
+      return this.plugins.filter(
         plugin => plugin.constructor.identifier === pluginId
-      ).forEach (plugin => {
+      ).some(plugin => {
         if (plugin.reload && plugin.reload(path, options)) {
-          return;
+          return true;
         }
-      })
+      });
     });
   }
 

--- a/src/reloader.js
+++ b/src/reloader.js
@@ -160,6 +160,13 @@ class Reloader {
         this.reloadPage();
         return true;
       }
+      if (pluginId === 'external') {
+        return this.plugins.some(plugin => {
+          if (plugin.reload && plugin.reload(path, options)) {
+            return true;
+          }
+        });
+      }
 
       return this.plugins.filter(
         plugin => plugin.constructor.identifier === pluginId

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -77,6 +77,15 @@ describe('Options', function () {
     return assert.strictEqual(true, options.https);
   });
 
+  it('should extract pluginOrder as array', function () {
+    const dom = new JSDOM('<script src="http://somewhere.com:9876/livereload.js?pluginOrder=css,others"></script>');
+
+    const options = Options.extract(dom.window.document);
+    assert.ok(options);
+    assert.deepStrictEqual(['css', 'others'], options.pluginOrder);
+    return assert.strictEqual(9876, options.port);
+  });
+
   return it('should recognize protocol-relative https URL', function () {
     const dom = new JSDOM('<script src="//somewhere.com/132324324/23243443/4343/livereload.js"></script>', {
       url: 'https://somewhere.org/'

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -40,6 +40,15 @@ describe('Options', function () {
     return assert.strictEqual(2, options.extver);
   });
 
+  it('should extract pluginOrder as array', function () {
+    const dom = new JSDOM('<script src="http://somewhere.com:9876/livereload.js?pluginOrder=css,others"></script>');
+
+    const options = Options.extract(dom.window.document);
+    assert.ok(options);
+    assert.deepStrictEqual(['css', 'others'], options.pluginOrder);
+    return assert.strictEqual(9876, options.port);
+  });
+
   it('should be cool with a strange URL', function () {
     const dom = new JSDOM('<script src="safari-ext://132324324/23243443/4343/livereload.js?host=somewhere.com"></script>');
 
@@ -75,15 +84,6 @@ describe('Options', function () {
     const options = Options.extract(dom.window.document);
     assert.ok(options);
     return assert.strictEqual(true, options.https);
-  });
-
-  it('should extract pluginOrder as array', function () {
-    const dom = new JSDOM('<script src="http://somewhere.com:9876/livereload.js?pluginOrder=css,others"></script>');
-
-    const options = Options.extract(dom.window.document);
-    assert.ok(options);
-    assert.deepStrictEqual(['css', 'others'], options.pluginOrder);
-    return assert.strictEqual(9876, options.port);
   });
 
   return it('should recognize protocol-relative https URL', function () {

--- a/test/reloader_test.js
+++ b/test/reloader_test.js
@@ -216,5 +216,36 @@ describe('Reloader', () => {
         pluginOrder: 'others css'.split(' ')
       });
     });
+
+    it('should not reload the page with liveCSS and css file updated', (done) => {
+      const reloader = new Reloader(
+        {
+          document: {
+            location: {
+              reload () {
+                throw new Error('Shall not reload!');
+              }
+            },
+            getElementsByTagName () { return []; }
+          }
+        },
+        console,
+        Timer
+      );
+
+      const message = {
+        path: '/abc.css'
+      };
+
+      reloader.reload(message.path, {
+        liveCSS: true,
+        reloadMissingCSS: false,
+        pluginOrder: 'css others'.split(' ')
+      });
+
+      setTimeout(() => {
+        done(); // no reload after 100ms
+      }, 100);
+    });
   });
 });

--- a/test/reloader_test.js
+++ b/test/reloader_test.js
@@ -134,7 +134,7 @@ describe('Reloader', () => {
             getElementsByTagName () { return []; }
           }
         },
-        console,
+        { log () {} },
         Timer
       );
 
@@ -231,7 +231,7 @@ describe('Reloader', () => {
             getElementsByTagName () { return []; }
           }
         },
-        console,
+        { log () {} },
         Timer
       );
 

--- a/test/reloader_test.js
+++ b/test/reloader_test.js
@@ -12,14 +12,13 @@ ThisDocPlugin.identifier = 'this-doc';
 ThisDocPlugin.version = '1.0';
 
 ThisDocPlugin.prototype.reload = function (path, options) {
-
   if (
     path !== this.window.location.pathname &&
     path !== this.window.location.pathname + 'index.html'
   ) {
     return true;
   }
-}
+};
 
 ThisDocPlugin.prototype.analyze = function () {
   return {
@@ -59,10 +58,9 @@ describe('Reloader', () => {
     });
 
     it('should reload when doc at the same location changed', (done) => {
-      const window = { document: { location: {
-        pathname: '/1.html',
-        reload: done
-      } } };
+      const window = {
+        document: { location: { pathname: '/1.html', reload: done } }
+      };
       window.location = window.document.location;
       const reloader = new Reloader(
         window,
@@ -70,7 +68,7 @@ describe('Reloader', () => {
         Timer
       );
 
-      reloader.addPlugin (new ThisDocPlugin (window));
+      reloader.addPlugin(new ThisDocPlugin(window));
 
       const message = {
         path: '/1.html'
@@ -82,17 +80,21 @@ describe('Reloader', () => {
         reloadMissingCSS: true,
         originalPath: '',
         overrideURL: '',
-        serverURL: 'http://localhost:9876',
+        serverURL: 'http://localhost:9876'
       });
     });
 
     it('should not reload when different html changed', (done) => {
-      const window = { document: { location: {
-        pathname: '/1.html',
-        reload() {
-          throw "Shall not reload!"
+      const window = {
+        document: {
+          location: {
+            pathname: '/1.html',
+            reload () {
+              throw new Error('Shall not reload!');
+            }
+          }
         }
-      } } };
+      };
       window.location = window.document.location;
       const reloader = new Reloader(
         window,
@@ -100,7 +102,7 @@ describe('Reloader', () => {
         Timer
       );
 
-      reloader.addPlugin (new ThisDocPlugin (window));
+      reloader.addPlugin(new ThisDocPlugin(window));
 
       const message = {
         path: '/2.html'
@@ -112,23 +114,26 @@ describe('Reloader', () => {
         reloadMissingCSS: true,
         originalPath: '',
         overrideURL: '',
-        serverURL: 'http://localhost:9876',
+        serverURL: 'http://localhost:9876'
       });
 
       setTimeout(() => {
         done(); // no reload after 100ms
       }, 100);
-
     });
 
     it('should not reload the page with liveCSS and css file updated', (done) => {
       const reloader = new Reloader(
-        { document: {
-          location: { reload() {
-            throw "Shall not reload!"
-          } },
-          getElementsByTagName () {return []}
-        } },
+        {
+          document: {
+            location: {
+              reload () {
+                throw new Error('Shall not reload!');
+              }
+            },
+            getElementsByTagName () { return []; }
+          }
+        },
         console,
         Timer
       );
@@ -139,7 +144,7 @@ describe('Reloader', () => {
 
       reloader.reload(message.path, {
         liveCSS: true,
-        reloadMissingCSS: false,
+        reloadMissingCSS: false
       });
 
       setTimeout(() => {
@@ -172,9 +177,7 @@ describe('Reloader', () => {
 
     it('should not reload with unknown url and no `others` plugin', (done) => {
       const reloader = new Reloader(
-        { document: { location: { reload() {
-          throw "Shall not reload!"
-        } } } },
+        { document: { location: { reload () { throw new Error('Shall not reload!'); } } } },
         console,
         Timer
       );
@@ -196,7 +199,6 @@ describe('Reloader', () => {
       setTimeout(() => {
         done(); // no reload after 100ms
       }, 100);
-
     });
 
     it('should reload anyway', (done) => {

--- a/test/reloader_test.js
+++ b/test/reloader_test.js
@@ -147,4 +147,74 @@ describe('Reloader', () => {
       }, 100);
     });
   });
+  describe('reload() with plugin order', () => {
+    it('should reload with same plugin order', (done) => {
+      const reloader = new Reloader(
+        { document: { location: { reload: done } } },
+        console,
+        Timer
+      );
+
+      const message = {
+        path: '/abc'
+      };
+
+      reloader.reload(message.path, {
+        liveCSS: true,
+        liveImg: true,
+        reloadMissingCSS: true,
+        originalPath: '',
+        overrideURL: '',
+        serverURL: 'http://localhost:9876',
+        pluginOrder: 'css img extension others'.split(' ')
+      });
+    });
+
+    it('should not reload with unknown url and no `others` plugin', (done) => {
+      const reloader = new Reloader(
+        { document: { location: { reload() {
+          throw "Shall not reload!"
+        } } } },
+        console,
+        Timer
+      );
+
+      const message = {
+        path: '/abc'
+      };
+
+      reloader.reload(message.path, {
+        liveCSS: true,
+        liveImg: true,
+        reloadMissingCSS: true,
+        originalPath: '',
+        overrideURL: '',
+        serverURL: 'http://localhost:9876',
+        pluginOrder: 'css img extension'.split(' ')
+      });
+
+      setTimeout(() => {
+        done(); // no reload after 100ms
+      }, 100);
+
+    });
+
+    it('should reload anyway', (done) => {
+      const reloader = new Reloader(
+        { document: { location: { reload: done } } },
+        console,
+        Timer
+      );
+
+      const message = {
+        path: '/abc.css'
+      };
+
+      reloader.reload(message.path, {
+        liveCSS: true,
+        reloadMissingCSS: true,
+        pluginOrder: 'others css'.split(' ')
+      });
+    });
+  });
 });


### PR DESCRIPTION
As of version 3.0.1 (and earlier) plugin order is always the same:

1. external plugins in order by `LiveReload.addPlugin()`;
2. liveCSS;
3. liveImg;
4. browser extension;
5. all other files

So, if no other plugin claims file ownership, page is always reloaded.

This patch allows to change plugin order and even turn off some plugins (like **all other files** _plugin_).

To activate plugin order, message should contain `pluginOrder` option with array of plugin identifiers. Those identifiers should resolve to internal _plugins_ (`css`, `img`, `extension` and `others`) or external ones (by `plugin.identifier`).

Fixes #59 