### PR TITLE
fix get port from  element.getAttribute('src') when no port on elemen…

### DIFF
--- a/dist/livereload.js
+++ b/dist/livereload.js
@@ -2733,7 +2733,9 @@ Options.extract = function (document) {
     var srcAttr = element.getAttribute('src');
     var lrUrlRegexp = /^([^:]+:\/\/([^/:]+)(?::(\d+))?\/|\/\/|\/)?([^/].*\/)?z?livereload\.js(?:\?(.*))?$/; //                   ^proto:// ^host       ^port     ^//  ^/   ^folder
 
-    if ((m = src.match(lrUrlRegexp)) && (mm = srcAttr.match(lrUrlRegexp))) {
+    var lrUrlRegexpAttr = /^(?:(?:([^:/]+)?:?)\/{0,2})([^:]+)(?::(\d+))?/; //                              ^proto             ^host/folder ^port
+
+    if ((m = src.match(lrUrlRegexp)) && (mm = srcAttr.match(lrUrlRegexpAttr))) {
       var _m = m,
           _m2 = _slicedToArray(_m, 6),
           host = _m2[2],

--- a/src/options.js
+++ b/src/options.js
@@ -38,7 +38,9 @@ Options.extract = function (document) {
     var src = element.src; var srcAttr = element.getAttribute('src');
     var lrUrlRegexp = /^([^:]+:\/\/([^/:]+)(?::(\d+))?\/|\/\/|\/)?([^/].*\/)?z?livereload\.js(?:\?(.*))?$/;
     //                   ^proto:// ^host       ^port     ^//  ^/   ^folder
-    if ((m = src.match(lrUrlRegexp)) && (mm = srcAttr.match(lrUrlRegexp))) {
+    var lrUrlRegexpAttr = /^(?:(?:([^:/]+)?:?)\/{0,2})([^:]+)(?::(\d+))?/;
+    //                              ^proto             ^host/folder ^port
+    if ((m = src.match(lrUrlRegexp)) && (mm = srcAttr.match(lrUrlRegexpAttr))) {
       const [, , host, port, , params] = m;
       const [, , , portFromAttr] = mm;
       const options = new Options();

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -90,6 +90,7 @@ describe('Options', function () {
     return assert.strictEqual(80, options.port);
 
   });
+  
   it('should recognize port 443', function () {
     let dom = new JSDOM('<script src="https://somewhere.com:443/132324324/23243443/4343/livereload.js"></script>');
     let options = Options.extract(dom.window.document);

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -117,7 +117,7 @@ describe('Options', function () {
   });
 
   it('should recognize same site URLs', function () {
-    let dom = new JSDOM('<script src="/somewhere.com:80/132324324/23243443/4343/livereload.js"></script>', {
+    let dom = new JSDOM('<script src="/somewhere.com/132324324/23243443/4343/livereload.js"></script>', {
       url: 'https://somewhere.org/'
     });
     let options = Options.extract(dom.window.document);

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -131,13 +131,6 @@ describe('Options', function () {
     assert.ok(options);
     assert.strictEqual('somewhere.org', options.host);
 
-    dom = new JSDOM('<script src="/somewhere.com/132324324/23243443/4343/livereload.js"></script>', {
-      url: 'https://somewhere.org/'
-    });
-    options = Options.extract(dom.window.document);
-    assert.ok(options);
-    assert.strictEqual('somewhere.org', options.host);
-
     dom = new JSDOM('<script src="livereload.js"></script>', {
       url: 'https://somewhere.org/'
     });

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -72,25 +72,69 @@ describe('Options', function () {
   });
 
   it('should recognize port 80', function () {
-    const dom = new JSDOM('<script src="http://somewhere.com:80/132324324/23243443/4343/livereload.js"></script>');
-    const options = Options.extract(dom.window.document);
+    let dom = new JSDOM('<script src="http://somewhere.com:80/132324324/23243443/4343/livereload.js"></script>');
+    let options = Options.extract(dom.window.document);
+    assert.ok(options);
+    assert.strictEqual(80, options.port);
+
+    dom = new JSDOM('<script src="//somewhere.com:80/132324324/23243443/4343/livereload.js"></script>');
+    options = Options.extract(dom.window.document);
+    assert.ok(options);
+    assert.strictEqual(80, options.port);
+
+    dom = new JSDOM('<script src="/somewhere.com:80/132324324/23243443/4343/livereload.js"></script>', {
+      url: 'https://somewhere.org/'
+    });
+    options = Options.extract(dom.window.document);
     assert.ok(options);
     return assert.strictEqual(80, options.port);
+
+  });
+  it('should recognize port 443', function () {
+    let dom = new JSDOM('<script src="https://somewhere.com:443/132324324/23243443/4343/livereload.js"></script>');
+    let options = Options.extract(dom.window.document);
+    assert.ok(options);
+    assert.strictEqual(443, options.port);
+
+    dom = new JSDOM('<script src="//somewhere.com:443/132324324/23243443/4343/livereload.js"></script>');
+    options = Options.extract(dom.window.document);
+    assert.ok(options);
+    assert.strictEqual(443, options.port);
+
+    dom = new JSDOM('<script src="/somewhere.com:443/132324324/23243443/4343/livereload.js"></script>', {
+      url: 'https://somewhere.org/'
+    });
+    options = Options.extract(dom.window.document);
+    assert.ok(options);
+    return assert.strictEqual(443, options.port);
   });
 
   it('should set https when using an https URL', function () {
     const dom = new JSDOM('<script src="https://somewhere.com:9876/livereload.js"></script>');
-
     const options = Options.extract(dom.window.document);
     assert.ok(options);
     return assert.strictEqual(true, options.https);
   });
 
   it('should recognize same site URLs', function () {
-    let dom = new JSDOM('<script src="/somewhere.com/132324324/23243443/4343/livereload.js"></script>', {
+    let dom = new JSDOM('<script src="/somewhere.com:80/132324324/23243443/4343/livereload.js"></script>', {
       url: 'https://somewhere.org/'
     });
     let options = Options.extract(dom.window.document);
+    assert.ok(options);
+    assert.strictEqual('somewhere.org', options.host);
+
+    dom = new JSDOM('<script src="/somewhere.com:443/132324324/23243443/4343/livereload.js"></script>', {
+      url: 'https://somewhere.org/'
+    });
+    options = Options.extract(dom.window.document);
+    assert.ok(options);
+    assert.strictEqual('somewhere.org', options.host);
+
+    dom = new JSDOM('<script src="/somewhere.com/132324324/23243443/4343/livereload.js"></script>', {
+      url: 'https://somewhere.org/'
+    });
+    options = Options.extract(dom.window.document);
     assert.ok(options);
     assert.strictEqual('somewhere.org', options.host);
 


### PR DESCRIPTION
…t.src

Extracting port with regExp `lrUrlRegexp` do not work when 
`src` is of the form  `"https://foo.com/livereload.js?snipver=1"`
and 
`srcAttr` of the form `"//foo.com:443/livereload.js?snipver=1"`

Pull request Fix that by using a specific regexp to use with `srcAttr`
Added some test trying to mimic this situation.