### PR TITLE
Allow livereload to optionally run behind a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Options can either be specified as query parameters of the `<script src="..../li
 The set of supported options is the same for both methods:
 
 * `host`: the host that runs a LiveReload server; required if specifying `LiveReloadOptions`, otherwise will be autodetected as the origin of the `<script>` tag
-* `port`: optional server port override
+* `port`: optional server port override; if set to blank it will inherit the port of the hosting page (and can be put behind a proxy)
 * `path`: optional path to livereload server (default: 'livereload')
 * `mindelay`, `maxdelay`: range of reconnection delays (if `livereload.js` cannot connect to the server, it will attempt to reconnect with increasing delays); defaults to 1,000 ms minimum and 60,000 ms maximum
 * `handshake_timeout`: timeout for a protocol handshake to be completed after a connection attempt; mostly only needed if you're running an interactive debugger on your web socket server

--- a/src/options.js
+++ b/src/options.js
@@ -25,7 +25,7 @@ class Options {
       return;
     }
 
-    if (!isNaN(+value)) {
+    if (value && !isNaN(+value)) {
       value = +value;
     }
 

--- a/src/options.js
+++ b/src/options.js
@@ -54,11 +54,13 @@ Options.extract = function (document) {
       options.https = element.src.indexOf('https') === 0;
 
       options.host = host;
-      options.port = port
-        ? parseInt(port, 10)
-        : portFromAttr
-          ? parseInt(portFromAttr, 10)
-          : options.port;
+
+      // use port number that the script is loaded from as default
+      // for explicitly blank value; enables livereload through proxy
+      const ourPort = parseInt(port || portFromAttr, 10) || '';
+
+      // if port is specified in script use that as default instead
+      options.port = ourPort || options.port;
 
       if (params) {
         for (const pair of params.split('&')) {
@@ -70,6 +72,11 @@ Options.extract = function (document) {
           }
         }
       }
+
+      // if port was overwritten by empty value, then revert to using the same
+      // port as the script is running from again (note that it shouldn't be
+      // coerced to a numeric value, since that will be 0 for the empty string)
+      options.port = options.port || ourPort;
 
       return options;
     }

--- a/src/options.js
+++ b/src/options.js
@@ -2,7 +2,14 @@ class Options {
   constructor () {
     this.https = false;
     this.host = null;
-    this.port = 35729;
+    let port = 35729;  // backing variable for port property closure
+
+    // we allow port to be overridden with a falsy value to indicate
+    // that we should not add a port specification to the backend url
+    Object.defineProperty(this, 'port', {
+      get () { return port; },
+      set (v) { port = (v && v || null); }
+    });
 
     this.snipver = null;
     this.ext = null;
@@ -25,7 +32,7 @@ class Options {
       return;
     }
 
-    if (value && !isNaN(+value)) {
+    if (!isNaN(+value)) {
       value = +value;
     }
 

--- a/src/options.js
+++ b/src/options.js
@@ -5,10 +5,11 @@ class Options {
     let port = 35729;  // backing variable for port property closure
 
     // we allow port to be overridden with a falsy value to indicate
-    // that we should not add a port specification to the backend url
+    // that we should not add a port specification to the backend url;
+    // port is now either a number, or a non-numeric string
     Object.defineProperty(this, 'port', {
       get () { return port; },
-      set (v) { port = (v && v || null); }
+      set (v) { port = (v ? (isNaN(v) ? v : +v) : ''); }
     });
 
     this.snipver = null;

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -138,19 +138,21 @@ describe('Options', function () {
     return assert.strictEqual(9090, options.port);
   });
 
-  it('should use invalid port parameter', function () {
+  it('should allow the port parameter to be set to blank', function () {
     let dom = new JSDOM('<script src="https://somewhere.com/livereload.js?port="></script>');
     let options = Options.extract(dom.window.document);
 
     assert.ok(options);
-    assert.strictEqual(0, options.port);
+    return assert.strictEqual('', options.port);
+  });
 
-    dom = new JSDOM('<script src="https://somewhere.com:8080/livereload.js?port="></script>');
+  it('should inherit the port parameter from the script URL if blank', function () {
+    let dom = new JSDOM('<script src="https://somewhere.com:8080/livereload.js?port="></script>');
 
-    options = Options.extract(dom.window.document);
+    let options = Options.extract(dom.window.document);
     assert.ok(options);
 
-    assert.strictEqual(0, options.port);
+    return assert.strictEqual(8080, options.port);
   });
 
   it('should propagate arbitrary port number when non-empty', function () {

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -151,10 +151,12 @@ describe('Options', function () {
     assert.ok(options);
 
     assert.strictEqual(0, options.port);
+  });
 
-    dom = new JSDOM('<script src="http://somewhere.com/livereload.js?port=abc"></script>');
+  it('should propagate arbitrary port number when non-empty', function () {
+    let dom = new JSDOM('<script src="http://somewhere.com/livereload.js?port=abc"></script>');
 
-    options = Options.extract(dom.window.document);
+    let options = Options.extract(dom.window.document);
     assert.ok(options);
 
     return assert.strictEqual('abc', options.port);


### PR DESCRIPTION
This changeset contains a series of patches to allow a livereload
server to run behind the same proxy that serves the web pages.

If the web pages are served over a secure connection through a proxy,
they cannot contact an insecure websocket. By instead routing the
livereload socket through the same server as the hosting web page, the
proxy can do the encryption for this traffic as well.

By specifying '?port=' as a parameter (i.e. an empty port value), we
now take this to mean that the livereload server should not be
contacted on any particular other port, but rather the same port as
the injected script. This setting also accomodates running the server
for the web pages themselves on a non-standard part (such as 8080).

Since empty port values wasn't possible to specify before, this change
shouldn't affect any existing configurations, only enable new ones.